### PR TITLE
Prevent adding default suffix if `-S` isn't passed

### DIFF
--- a/pyftfeatfreeze/pyftfeatfreeze.py
+++ b/pyftfeatfreeze/pyftfeatfreeze.py
@@ -285,7 +285,7 @@ class RemapByOTL(object):
         if not self.options.rename and not self.options.replacenames:
             return self.success
         suffix = " " + self.options.usesuffix
-        if suffix == " ":
+        if suffix == " " and self.options.rename:
             suffix = " ".join(sorted(self.filterByFeatures))
         if suffix == " ": 
             suffix = ""


### PR DESCRIPTION
This PR fixes a minor bug in the name of the output font in the case where you want to rename the font you're modifying, but don't want to add any suffix. Without this patch, if any renaming was done but a custom suffix wasn't specified, the default suffix would be used even if you hadn't specified the `-S` argument. E.g, if you wanted to create a small caps variant of 'Source Serif Pro' and wanted the output font to be called 'Small Caps Serif Pro', rather than 'Small Caps Serif Prosmcp'.